### PR TITLE
revert commit 619d109 that accidentally modified `escape_profiles_config.yaml`

### DIFF
--- a/data/escape_profiles_config.yaml
+++ b/data/escape_profiles_config.yaml
@@ -26,13 +26,220 @@
 #                  (using the short names defined as values in `conditions`),
 #                  and then the values are maps of site to the list [color, alpha]
 
-subject_G:  # name of plot
-  conditions:
+human_sera_oldnames:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: 23_d21
+    23_d45_1250: 23_d45
+    23_d120_500: 23_d120
+    1C_d26_200: 1C_d26
+    1C_d113_200: 1C_d113
+    24C_d32_200: 24C_d32
+    24C_d104_200: 24C_d104
+    6C_d33_500: 6C_d33
+    6C_d76_500: 6C_d76
+    22C_d28_200: 22C_d28
+    22C_d104_200: 22C_d104
+    25C_d48_200: 25C_d48
+    25C_d115_80: 25C_d115
+    25_d18_500: 25_d18
+    25_d94_200: 25_d94
+    12C_d61_160: 12C_d61
+    12C_d152_80: 12C_d152
+    23C_d26_80: 23C_d26
+    23C_d102_80: 23C_d102
+    13_d15_200: 13_d15
+    13_d121_1250: 13_d121
+    7C_d29_500: 7C_d29
+    7C_d103_200: 7C_d103
+  # plot automatically identified sites?
+  plot_auto_identified_sites: default
+  # add these sites if they aren't automatically identified
+  add_sites: [417,501]
+  # exclude these sites even if not automatically identified
+  exclude_sites: [361]
+  # name of site-level color scheme in `site_color_schemes.csv` **or**
+  # color for all sites
+  site_color_scheme: subdomain
+  # make escape profiles colored by DMS bind / expr measurements?
+  color_by_dms: True
+  # make supplemental data files for this antibody set
+  make_supp_data: true
+  # analyze naturally occurring mutations at strong sites of escape
+  analyze_natural_mutations: false
+  analyze_natural_mutations_specs:
+    also_label: [384,417,439,446,484,485,494,453,501, 477]
+    label_font_size: 7
+    default_color: black
+    label_font_size: 7
+    set_point_color:
+      484: '#004488'
+      477: '#004488'
+      417: '#004488'
+      501: '#66CCEE'
+      446: '#66CCEE'
+    escape: tot_site_escape
+    ylabel: total escape at site
+    label_minescape: 2.0
+  natural_mutations_mincounts: 5  # plot sites with >= this many mutation counts
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    23_d45_1250: subject A (day 45)
+    23_d120_500: subject A (day 120)
+    1C_d26_200: subject B (day 26)
+    1C_d113_200: subject B (day 113)
+    24C_d32_200: subject C (day 32)
+    24C_d104_200: subject C (day 104)
+    6C_d33_500: subject D (day 33)
+    6C_d76_500: subject D (day 76)
+    22C_d28_200: subject E (day 28)
+    22C_d104_200: subject E (day 104)
+    25C_d48_200: subject F (day 48)
+    25C_d115_80: subject F (day 115)
     25_d18_500: subject G (day 18)
     25_d94_200: subject G (day 94)
+    12C_d61_160: subject H (day 61)
+    12C_d152_80: subject H (day 152)
+    23C_d26_80: subject I (day 26)
+    23C_d102_80: subject I (day 102)
+    13_d15_200: subject J (day 15)
+    13_d121_1250: subject J (day 121)
+    7C_d29_500: subject K (day 29)
+    7C_d103_200: subject K (day 103)
+  # plot automatically identified sites?
+  plot_auto_identified_sites: default
+  # add these sites if they aren't automatically identified
+  add_sites: [417,501]
+  # exclude these sites even if not automatically identified
+  exclude_sites: [361]
+  # name of site-level color scheme in `site_color_schemes.csv` **or**
+  # color for all sites
+  site_color_scheme: serum_epitopes_OGCrowe
+  # make escape profiles colored by DMS bind / expr measurements?
+  color_by_dms: False
+  # make supplemental data files for this antibody set
+  make_supp_data: true
+  # analyze naturally occurring mutations at strong sites of escape
+  analyze_natural_mutations: true
+  natural_mutations_mincounts: 5  # plot sites with >= this many mutation counts
+  analyze_natural_mutations_specs:
+    also_label: [417, 439, 444, 446, 452, 453, 455, 456, 472, 477, 484, 485, 486, 490, 494, 501]
+    label_font_size: 7
+    default_color: '#999999'
+    default_alpha: 0.6
+    set_point_alpha:
+      417: 1
+      439: 1
+      444: 1
+      446: 1
+      452: 1
+      453: 1
+      455: 1
+      456: 1
+      472: 1
+      477: 1
+      484: 1
+      485: 1
+      486: 1
+      490: 1
+      494: 1
+      501: 1
+    set_point_color:
+      417: '#004488'
+      444: '#66CCEE'
+      446: '#66CCEE'
+      452: '#66CCEE'
+      455: '#004488'
+      456: '#004488'
+      472: '#004488'
+      477: '#004488'
+      484: '#004488'
+      485: '#004488'
+      486: '#004488'
+      490: '#004488'
+      494: '#66CCEE'
+      501: '#66CCEE'
+    escape: tot_site_escape
+    ylabel: total escape at site
+    label_minescape: 2
+    label_minfreq: 5e-5
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_figS3:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
+    7C_d29_500: subject K (day 29)
+    23_d45_1250: subject A (day 45)
+    23_d120_500: subject A (day 120)
+    1C_d113_200: subject B (day 113)
+    24C_d104_200: subject C (day 104)
+    6C_d76_500: subject D (day 76)
+    22C_d104_200: subject E (day 104)
+    25C_d115_80: subject F (day 115)
+    25_d94_200: subject G (day 94)
+    12C_d152_80: subject H (day 152)
+    23C_d102_80: subject I (day 102)
+    13_d121_1250: subject J (day 121)
+    7C_d103_200: subject K (day 103)
+  # plot automatically identified sites?
+  plot_auto_identified_sites: default
+  # add these sites if they aren't automatically identified
+  add_sites: [417,501]
+  # exclude these sites even if not automatically identified
+  exclude_sites: [361]
+  # name of site-level color scheme in `site_color_schemes.csv` **or**
+  # color for all sites
+  site_color_scheme: serum_epitopes_OGCrowe
+  # make escape profiles colored by DMS bind / expr measurements?
+  color_by_dms: True
+  # make supplemental data files for this antibody set
+  make_supp_data: False
+  # analyze naturally occurring mutations at strong sites of escape
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5  # plot sites with >= this many mutation counts
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+  dmslogo_draw_logo_kwargs:
+    widthscale: 0.8
+
+human_sera_fig4A_1C:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    1C_d26_200: subject B (day 26)
+    1C_d113_200: subject B (day 113)
   plot_auto_identified_sites: default
   # add the sites that are auto-identified for 1C, 24C, 25, and 7C
-  add_sites: [417, 439, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499, 501]
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
   exclude_sites: [361]
   site_color_scheme: serum_epitopes_OGCrowe
   escape_profile_ymax:
@@ -40,19 +247,115 @@ subject_G:  # name of plot
     frac: 0.05
     min_ymax: 1
   dmslogo_facet_plot_kwargs:
-    height_per_ax: 2.1
-  draw_line_plot: false
+    height_per_ax: 2.0
   dmslogo_draw_line_kwargs:
     widthscale: 0.64
 
-subjects_C_I_G_K:  # name of plot
-  conditions:  # antibodies / sera to show and names to use for them
+human_sera_fig4B_24C:  # name of plot
+  conditions:
     24C_d32_200: subject C (day 32)
-    23C_d26_80: subject I (day 26)
+    24C_d104_200: subject C (day 104)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_OGCrowe
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4C_25:  # name of plot
+  conditions:
     25_d18_500: subject G (day 18)
+    25_d94_200: subject G (day 94)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_OGCrowe
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4D_7C:  # name of plot
+  conditions:
+    7C_d29_500: subject K (day 29)
+    7C_d103_200: subject K (day 103)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_OGCrowe
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4E_25C:  # name of plot
+  conditions:
+    25C_d48_200: subject F (day 48)
+    25C_d115_80: subject F (day 115)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_OGCrowe
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4X_6C:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    6C_d33_500: subject D (day 33)
+    6C_d76_500: subject D (day 76)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_OGCrowe
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_early_fig2:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
     7C_d29_500: subject K (day 29)
   plot_auto_identified_sites: default
-  add_sites: [383, 384, 417, 439, 501]
+  add_sites: []
   exclude_sites: [361]
   draw_line_plot: true
   site_color_scheme: serum_epitopes_OGCrowe
@@ -66,7 +369,392 @@ subjects_C_I_G_K:  # name of plot
     min_ymax: 1
   dmslogo_facet_plot_kwargs:
     height_per_ax: 2.0
-  draw_line_plot: false
   dmslogo_draw_line_kwargs:
     widthscale: 0.64
 
+human_sera_early_fig2_417_501:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
+    7C_d29_500: subject K (day 29)
+  plot_auto_identified_sites: default
+  add_sites: [417,501]
+  exclude_sites: [361]
+  draw_line_plot: true
+  site_color_scheme: serum_epitopes_OGCrowe
+  color_by_dms: false
+  make_supp_data: false
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+  dmslogo_draw_logo_kwargs:
+    widthscale: 0.8
+
+2165_validation:
+  conditions:
+    COV2-2165_400: COV2-2165
+  plot_auto_identified_sites: false
+  add_sites: [420,456]
+  exclude_sites: []
+  site_color_scheme: gray
+  mutation_colors:
+    A456: '#D55E00'
+    K456: '#D55E00'
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  draw_line_plot: false
+
+CB6_validation:
+  conditions:
+    CB6_400: CB6
+  plot_auto_identified_sites: false
+  add_sites: [417,456]
+  exclude_sites: []
+  site_color_scheme: gray
+  mutation_colors:
+    A456: '#D55E00'
+    K456: '#D55E00'
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  draw_line_plot: false
+
+2082_validation:
+  conditions:
+    COV2-2082_400: COV2-2082
+  plot_auto_identified_sites: false
+  add_sites: [378,456]
+  exclude_sites: []
+  site_color_scheme: gray
+  mutation_colors:
+    A456: '#D55E00'
+    K456: '#D55E00'
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  draw_line_plot: false
+
+2832_validation:
+  conditions:
+    COV2-2832_400: COV2-2832
+  plot_auto_identified_sites: false
+  add_sites: [486,456]
+  exclude_sites: []
+  site_color_scheme: gray
+  mutation_colors:
+    A456: '#D55E00'
+    K456: '#D55E00'
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  draw_line_plot: false
+
+# now repeat everything with pinkpurple colors instead of OGCrowe
+human_sera_pink:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    23_d45_1250: subject A (day 45)
+    23_d120_500: subject A (day 120)
+    1C_d26_200: subject B (day 26)
+    1C_d113_200: subject B (day 113)
+    24C_d32_200: subject C (day 32)
+    24C_d104_200: subject C (day 104)
+    6C_d33_500: subject D (day 33)
+    6C_d76_500: subject D (day 76)
+    22C_d28_200: subject E (day 28)
+    22C_d104_200: subject E (day 104)
+    25C_d48_200: subject F (day 48)
+    25C_d115_80: subject F (day 115)
+    25_d18_500: subject G (day 18)
+    25_d94_200: subject G (day 94)
+    12C_d61_160: subject H (day 61)
+    12C_d152_80: subject H (day 152)
+    23C_d26_80: subject I (day 26)
+    23C_d102_80: subject I (day 102)
+    13_d15_200: subject J (day 15)
+    13_d121_1250: subject J (day 121)
+    7C_d29_500: subject K (day 29)
+    7C_d103_200: subject K (day 103)
+  # plot automatically identified sites?
+  plot_auto_identified_sites: default
+  # add these sites if they aren't automatically identified
+  add_sites: [417,501]
+  # exclude these sites even if not automatically identified
+  exclude_sites: [361]
+  # name of site-level color scheme in `site_color_schemes.csv` **or**
+  # color for all sites
+  site_color_scheme: serum_epitopes_pinkpurple
+  # make escape profiles colored by DMS bind / expr measurements?
+  color_by_dms: False
+  # make supplemental data files for this antibody set
+  make_supp_data: true
+  # analyze naturally occurring mutations at strong sites of escape
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5  # plot sites with >= this many mutation counts
+  analyze_natural_mutations_specs:
+    also_label: [384,417,439,446,484,485,494,453,501, 477]
+    label_font_size: 7
+    default_color: black
+    label_font_size: 7
+    set_point_color:
+      484: '#E52794'
+      477: '#E52794'
+      417: '#E52794'
+      501: '#670390'
+      446: '#670390'
+    escape: tot_site_escape
+    ylabel: total escape at site
+    label_minescape: 2.0
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_figS3_pink:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
+    7C_d29_500: subject K (day 29)
+    23_d45_1250: subject A (day 45)
+    23_d120_500: subject A (day 120)
+    1C_d113_200: subject B (day 113)
+    24C_d104_200: subject C (day 104)
+    6C_d76_500: subject D (day 76)
+    22C_d104_200: subject E (day 104)
+    25C_d115_80: subject F (day 115)
+    25_d94_200: subject G (day 94)
+    12C_d152_80: subject H (day 152)
+    23C_d102_80: subject I (day 102)
+    13_d121_1250: subject J (day 121)
+    7C_d103_200: subject K (day 103)
+  # plot automatically identified sites?
+  plot_auto_identified_sites: default
+  # add these sites if they aren't automatically identified
+  add_sites: [417,501]
+  # exclude these sites even if not automatically identified
+  exclude_sites: [361]
+  # name of site-level color scheme in `site_color_schemes.csv` **or**
+  # color for all sites
+  site_color_scheme: serum_epitopes_pinkpurple
+  # make escape profiles colored by DMS bind / expr measurements?
+  color_by_dms: True
+  # make supplemental data files for this antibody set
+  make_supp_data: False
+  # analyze naturally occurring mutations at strong sites of escape
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5  # plot sites with >= this many mutation counts
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+  dmslogo_draw_logo_kwargs:
+    widthscale: 0.8
+
+
+human_sera_fig4A_1C_pink:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    1C_d26_200: subject B (day 26)
+    1C_d113_200: subject B (day 113)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4B_24C_pink:  # name of plot
+  conditions:
+    24C_d32_200: subject C (day 32)
+    24C_d104_200: subject C (day 104)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4C_25_pink:  # name of plot
+  conditions:
+    25_d18_500: subject G (day 18)
+    25_d94_200: subject G (day 94)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4D_7C_pink:  # name of plot
+  conditions:
+    7C_d29_500: subject K (day 29)
+    7C_d103_200: subject K (day 103)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4E_25C_pink:  # name of plot
+  conditions:
+    25C_d48_200: subject F (day 48)
+    25C_d115_80: subject F (day 115)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [443, 444, 445, 446, 447, 448, 449, 450, 452, 456, 472, 473, 484, 490, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_fig4X_6C_pink:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    6C_d33_500: subject D (day 33)
+    6C_d76_500: subject D (day 76)
+  plot_auto_identified_sites: default
+  # add the sites that are auto-identified for 1C, 24C, 25, and 7C
+  add_sites: [365, 369, 396, 443, 444, 445, 446, 447, 448, 449, 450, 456, 484, 499]
+  exclude_sites: [361]
+  site_color_scheme: serum_epitopes_pinkpurple
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_early_fig2_pink:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
+    7C_d29_500: subject K (day 29)
+  plot_auto_identified_sites: default
+  add_sites: []
+  exclude_sites: [361]
+  draw_line_plot: true
+  site_color_scheme: serum_epitopes_pinkpurple
+  color_by_dms: false
+  make_supp_data: false
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+
+human_sera_early_fig2_pink_417_501:  # name of plot
+  conditions:  # antibodies / sera to show and names to use for them
+    23_d21_1250: subject A (day 21)
+    1C_d26_200: subject B (day 26)
+    24C_d32_200: subject C (day 32)
+    6C_d33_500: subject D (day 33)
+    22C_d28_200: subject E (day 28)
+    25C_d48_200: subject F (day 48)
+    25_d18_500: subject G (day 18)
+    12C_d61_160: subject H (day 61)
+    23C_d26_80: subject I (day 26)
+    13_d15_200: subject J (day 15)
+    7C_d29_500: subject K (day 29)
+  plot_auto_identified_sites: default
+  add_sites: [417,501]
+  exclude_sites: [361]
+  draw_line_plot: true
+  site_color_scheme: serum_epitopes_pinkpurple
+  color_by_dms: false
+  make_supp_data: false
+  analyze_natural_mutations: false
+  natural_mutations_mincounts: 5
+  escape_profile_ymax:
+    quantile: 0.5
+    frac: 0.05
+    min_ymax: 1
+  dmslogo_facet_plot_kwargs:
+    height_per_ax: 2.0
+  dmslogo_draw_line_kwargs:
+    widthscale: 0.64
+  dmslogo_draw_logo_kwargs:
+    widthscale: 0.8


### PR DESCRIPTION
@ajgreaney: this pull request reverts the commit that accidentally removed some of the escape profiles from that configuration file. I ran this, and checked that it produces the right output.

The source of the error was that I'd made a branch where I was streamlining some of the escape profiles for simpler Twitter figures. I then made the GISAID fix on that branch, and accidentally pushed both changes.

Can you review and merge. 